### PR TITLE
Add missing autoload cookie

### DIFF
--- a/arduino-mode.el
+++ b/arduino-mode.el
@@ -108,6 +108,7 @@ Each list item should be a regexp matching a single identifier." :group 'arduino
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pde\\'" . arduino-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ino\\'" . arduino-mode))
 
 ;;;###autoload


### PR DESCRIPTION
This commit ensures that users who have installed `arduino-mode` from a [MELPA](melpa.milkbox.net) package will be able to automatically turn on `arduino-mode` when visiting `ino` file without explicitly requiring the library first.
