### PR TITLE
Fix undefined cl-macrorepxand-all under Emacs 24.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: emacs-lisp
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+before_install:
+  - export PATH="$HOME/.evm/bin:$PATH"
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use --skip
+script:
+  - emacs --version
+  - emacs -Q -batch -f batch-byte-compile *.el

--- a/arduino-mode.el
+++ b/arduino-mode.el
@@ -32,6 +32,7 @@
 (require 'cc-mode)
 
 (eval-when-compile
+  (require 'cl)
   (require 'cc-langs)
   (require 'cc-fonts)
   (require 'cc-menus))


### PR DESCRIPTION
Compilation is failing under Emacs 24.4 with the following error:

    Symbol's function definition is void: cl-macroexpand-all

The problem appears to be due to Emacs bug [#18845])(http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18845). The gist of which is that cc-mode uses cl at compile time, but doesn't require it. Requiring cl at compile time seems to fix it.

Fixes #9.
